### PR TITLE
refactor(@lib/errors): Rename error enums and use symbols instead of strings

### DIFF
--- a/lib/create-config/src/create-config.test.js
+++ b/lib/create-config/src/create-config.test.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { createConfig } from './create-config';
 
@@ -15,7 +15,7 @@ describe('# @lib/create-config', () => {
 
   describe('when evironment variables is not set', () => {
     it('should throw', () => {
-      expect(() => createConfig()).toThrow(errors.Config);
+      expect(() => createConfig()).toThrow(Errors.Config);
     });
   });
 
@@ -23,7 +23,7 @@ describe('# @lib/create-config', () => {
     describe('when evironment variables is invalid', () => {
       it('should throw', () => {
         process.env['DB_AUTH'] = 'simple';
-        expect(() => createConfig()).toThrow(errors.Validation);
+        expect(() => createConfig()).toThrow(Errors.Validation);
       });
     });
 

--- a/lib/create-config/src/create-db-config/create-db-config.js
+++ b/lib/create-config/src/create-db-config/create-db-config.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { toNumber } from '../mappers';
 
@@ -17,7 +17,7 @@ export const createDbConfig = () => {
   if (auth === AUTH_METHOD.SIMPLE) return { ...common, password };
   if (auth === AUTH_METHOD.IAM) return { ...common, region };
 
-  throw new errors.Config(
+  throw new Errors.Config(
     `Database auth method "${auth}" is invalid. "DB_AUTH" environment variable must be one this values: "${Object.values(
       AUTH_METHOD,
     ).join(', ')}"`,

--- a/lib/create-db/src/create-client-factory/create-client-factory.js
+++ b/lib/create-db/src/create-client-factory/create-client-factory.js
@@ -1,5 +1,5 @@
 import { Client } from 'pg';
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { createConnectionHooks } from './create-connection-hooks';
 
@@ -22,7 +22,7 @@ export const createClientFactory = (config) => () => {
 
 const createAtomicQuery = (client) => async (query, values) =>
   client.query(query, values).catch((error) => {
-    throw new errors.Query(
+    throw new Errors.Query(
       `Unable to process query "${query}" with values "${values}"`,
       error,
     );

--- a/lib/create-db/src/create-client-factory/create-client-factory.test.js
+++ b/lib/create-db/src/create-client-factory/create-client-factory.test.js
@@ -1,4 +1,4 @@
-import { types } from '@lib/errors';
+import { ErrorTypes } from '@lib/errors';
 
 import { createClientFactory } from './create-client-factory';
 
@@ -39,8 +39,8 @@ describe('# @lib/create-db::createClientFactory', () => {
           const error = await connect().catch((error) => error);
           expect(error).toMatchObject({
             message: 'An error occured while try to connect to database',
-            type: types.DATA_ACCESS.name,
-            code: types.DATA_ACCESS.codes.CONNECTION,
+            type: ErrorTypes.DATA_ACCESS.name,
+            code: ErrorTypes.DATA_ACCESS.codes.CONNECTION,
           });
         });
       });
@@ -60,8 +60,8 @@ describe('# @lib/create-db::createClientFactory', () => {
           );
           expect(error).toMatchObject({
             message: 'Unable to process query "SQL" with values "value"',
-            type: types.DATA_ACCESS.name,
-            code: types.DATA_ACCESS.codes.QUERY,
+            type: ErrorTypes.DATA_ACCESS.name,
+            code: ErrorTypes.DATA_ACCESS.codes.QUERY,
           });
         });
       });

--- a/lib/create-db/src/create-client-factory/create-connection-hooks.js
+++ b/lib/create-db/src/create-client-factory/create-connection-hooks.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 export const createConnectionHooks = (client) => {
   const connect = createHook({
@@ -19,7 +19,7 @@ const createHook = ({ client, methodName, errorMessage }) => {
     try {
       await method();
     } catch (error) {
-      throw new errors.Connection(errorMessage, error);
+      throw new Errors.Connection(errorMessage, error);
     }
   };
 };

--- a/lib/create-db/src/create-db-config/create-db-config.js
+++ b/lib/create-db/src/create-db-config/create-db-config.js
@@ -1,6 +1,6 @@
 import { RDS } from 'aws-sdk';
 import { DB_AUTH_METHOD } from '@lib/create-config';
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 export const createDbConfig = ({ auth, region, ...common }) => {
   const pgConfig = { ...common, keepAlive: true };
@@ -8,7 +8,7 @@ export const createDbConfig = ({ auth, region, ...common }) => {
   if (auth === DB_AUTH_METHOD.IAM)
     return { ...pgConfig, password: getIamToken({ ...common, region }) };
 
-  throw new errors.Config(
+  throw new Errors.Config(
     `Database auth method "${auth}" is invalid. "config.auth" value must be one this values: "${Object.values(
       DB_AUTH_METHOD,
     ).join(', ')}"`,

--- a/lib/create-db/src/create-db-config/create-db-config.test.js
+++ b/lib/create-db/src/create-db-config/create-db-config.test.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { createDbConfig } from './create-db-config';
 
@@ -54,7 +54,7 @@ describe('# @lib/create-db::createDbConfig', () => {
       const password = 'password';
       const region = 'region';
       const dbConfig = { host, port, database, user, password, region };
-      expect(() => createDbConfig(dbConfig)).toThrow(errors.Config);
+      expect(() => createDbConfig(dbConfig)).toThrow(Errors.Config);
     });
   });
 });

--- a/lib/create-db/src/create-db.test.js
+++ b/lib/create-db/src/create-db.test.js
@@ -1,5 +1,5 @@
 import { DB_AUTH_METHOD } from '@lib/create-config';
-import { types } from '@lib/errors';
+import { ErrorTypes } from '@lib/errors';
 
 import { createDb } from './create-db';
 
@@ -28,8 +28,8 @@ describe('# @lib/create-db', () => {
         const error = await query('SQL', ['value']).catch((error) => error);
         expect(error).toMatchObject({
           message: 'An error occured while try to connect to database',
-          type: types.DATA_ACCESS.name,
-          code: types.DATA_ACCESS.codes.CONNECTION,
+          type: ErrorTypes.DATA_ACCESS.name,
+          code: ErrorTypes.DATA_ACCESS.codes.CONNECTION,
         });
       });
     });
@@ -44,8 +44,8 @@ describe('# @lib/create-db', () => {
         }).catch((error) => error);
         expect(error).toMatchObject({
           message: 'An error occured while try to connect to database',
-          type: types.DATA_ACCESS.name,
-          code: types.DATA_ACCESS.codes.CONNECTION,
+          type: ErrorTypes.DATA_ACCESS.name,
+          code: ErrorTypes.DATA_ACCESS.codes.CONNECTION,
         });
       });
     });

--- a/lib/create-validate/src/create-validate.js
+++ b/lib/create-validate/src/create-validate.js
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import { commonJSONSchemas } from '@lib/common-json-schemas';
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 export const createValidate = (schemaOrSchemaWithReferences = {}) => {
   if (isEmptySchema(schemaOrSchemaWithReferences)) return isAlwaysValid;
@@ -15,7 +15,7 @@ export const createValidate = (schemaOrSchemaWithReferences = {}) => {
     .compile(schema);
   return (data) => {
     if (validate(data)) return data;
-    throw new errors.Validation(schema.title, validate.errors);
+    throw new Errors.Validation(schema.title, validate.errors);
   };
 };
 

--- a/lib/create-validate/src/create-validate.test.js
+++ b/lib/create-validate/src/create-validate.test.js
@@ -1,3 +1,5 @@
+import { ErrorTypes } from '@lib/errors';
+
 import { createValidate } from './create-validate';
 
 const catchError = (callback) => {
@@ -54,7 +56,7 @@ describe('# @lib/create-validation', () => {
         it('should throw error', () => {
           const error = catchError(() => validate({}));
           expect(error).toMatchObject({
-            type: 'validation',
+            type: ErrorTypes.VALIDATION.name,
             message: 'An error accure while validating Model',
             errors: [
               {
@@ -129,7 +131,7 @@ describe('# @lib/create-validation', () => {
         it('should throw error', () => {
           const error = catchError(() => validate({}));
           expect(error).toMatchObject({
-            type: 'validation',
+            type: ErrorTypes.VALIDATION.name,
             message: 'An error accure while validating Model',
             errors: [
               {

--- a/lib/errors/errors.js
+++ b/lib/errors/errors.js
@@ -1,6 +1,6 @@
 import { format } from 'util';
 
-export const types = {
+export const ErrorTypes = {
   VALIDATION: {
     name: 'validation',
   },
@@ -39,31 +39,31 @@ class Validation extends BaseError {
     );
     this.errors = errors;
   }
-  type = types.VALIDATION.name;
+  type = ErrorTypes.VALIDATION.name;
 }
 class Config extends BaseError {
-  type = types.CONFIG.name;
+  type = ErrorTypes.CONFIG.name;
 }
 class Domain extends BaseError {
-  type = types.DOMAIN.name;
+  type = ErrorTypes.DOMAIN.name;
 }
 class NotFound extends BaseError {
-  type = types.DATA_ACCESS.name;
-  code = types.DATA_ACCESS.codes.NOT_FOUND;
+  type = ErrorTypes.DATA_ACCESS.name;
+  code = ErrorTypes.DATA_ACCESS.codes.NOT_FOUND;
 }
 class Connection extends BaseError {
-  type = types.DATA_ACCESS.name;
-  code = types.DATA_ACCESS.codes.CONNECTION;
+  type = ErrorTypes.DATA_ACCESS.name;
+  code = ErrorTypes.DATA_ACCESS.codes.CONNECTION;
 }
 class Query extends BaseError {
-  type = types.DATA_ACCESS.name;
-  code = types.DATA_ACCESS.codes.QUERY;
+  type = ErrorTypes.DATA_ACCESS.name;
+  code = ErrorTypes.DATA_ACCESS.codes.QUERY;
 }
 class BadRequest extends BaseError {
-  type = types.HTTP.name;
-  code = types.HTTP.codes.BAD_REQUEST;
+  type = ErrorTypes.HTTP.name;
+  code = ErrorTypes.HTTP.codes.BAD_REQUEST;
 }
-export const errors = {
+export const Errors = {
   Validation,
   Config,
   Domain,

--- a/lib/errors/errors.js
+++ b/lib/errors/errors.js
@@ -2,26 +2,26 @@ import { format } from 'util';
 
 export const ErrorTypes = {
   VALIDATION: {
-    name: 'validation',
+    name: Symbol('validation'),
   },
   CONFIG: {
-    name: 'config',
+    name: Symbol('config'),
   },
   DOMAIN: {
-    name: 'domain',
+    name: Symbol('domain'),
   },
   DATA_ACCESS: {
-    name: 'data-access',
+    name: Symbol('data-access'),
     codes: {
-      NOT_FOUND: 'not-found',
-      CONNECTION: 'connection',
-      QUERY: 'query',
+      NOT_FOUND: Symbol('not-found'),
+      CONNECTION: Symbol('connection'),
+      QUERY: Symbol('query'),
     },
   },
   HTTP: {
-    name: 'http',
+    name: Symbol('http'),
     codes: {
-      BAD_REQUEST: 'bad-request',
+      BAD_REQUEST: Symbol('bad-request'),
     },
   },
 };

--- a/services/product/src/create-get-product-by-id/create-get-product-by-id.test.js
+++ b/services/product/src/create-get-product-by-id/create-get-product-by-id.test.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 import { products } from '@lib/mock-data';
 
 import { createGetProductById } from './create-get-product-by-id';
@@ -25,14 +25,14 @@ describe('# @services/product::createGetProductById', () => {
     it('should throw "not found" error', async () => {
       expect.assertions(2);
       const getProduct = async (id) => {
-        throw new errors.NotFound(`Product with id "${id}" not found`);
+        throw new Errors.NotFound(`Product with id "${id}" not found`);
       };
       const repo = { getProduct };
       const getProductById = createGetProductById({ repo });
       const error = await getProductById({
         params: { id: 'non-existent-id' },
       }).catch((error) => error);
-      await expect(error).toBeInstanceOf(errors.NotFound);
+      await expect(error).toBeInstanceOf(Errors.NotFound);
       await expect(error.message).toBe(
         'Product with id "non-existent-id" not found',
       );

--- a/services/product/src/create-repo/methods/create-product.test.js
+++ b/services/product/src/create-repo/methods/create-product.test.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { createProduct as createProductFactory } from './create-product';
 
@@ -57,7 +57,7 @@ describe('# @services/prodcut::createRepo::createProduct', () => {
       it('should throw query error', async () => {
         const noop = () => {};
         const query = jest.fn(async () => {
-          throw new errors.Query('query error');
+          throw new Errors.Query('query error');
         });
         const transaction = async (queryCallback) => {
           await queryCallback(query);

--- a/services/product/src/create-repo/methods/get-product.js
+++ b/services/product/src/create-repo/methods/get-product.js
@@ -1,4 +1,4 @@
-import { errors } from '@lib/errors';
+import { Errors } from '@lib/errors';
 
 import { SELECT_PRODUCTS_QUERY } from './sql-queries';
 
@@ -10,6 +10,6 @@ export const getProduct =
       rows: [product],
     } = await query(sqlQuery, [productId]);
     if (!product)
-      throw new errors.NotFound(`Product with id "${productId}" not found`);
+      throw new Errors.NotFound(`Product with id "${productId}" not found`);
     return product;
   };

--- a/services/product/src/create-repo/methods/get-product.test.js
+++ b/services/product/src/create-repo/methods/get-product.test.js
@@ -1,3 +1,4 @@
+import { ErrorTypes } from '@lib/errors';
 import { products } from '@lib/mock-data';
 
 import { getProduct as getProductFactory } from './get-product';
@@ -41,8 +42,8 @@ describe('# @services/prodcut::createRepo::getProduct', () => {
       const error = await getProduct('id').catch((err) => err);
       expect(error).toMatchObject({
         message: 'Product with id "id" not found',
-        type: 'data-access',
-        code: 'not-found',
+        type: ErrorTypes.DATA_ACCESS.name,
+        code: ErrorTypes.DATA_ACCESS.codes.NOT_FOUND,
       });
     });
   });


### PR DESCRIPTION
- chore: cleanup project package.json files
- chore(deps): add @babel/node development dependency
- refactor(test): lineup test's descriptions
- refactor(tests): remove useless jest.fn arguments
- refactor(@lib/errors): rename errors and error types enums
- refactor(@lib/errors): use Symbols for the types and codes instead of string
- refactor(lib/aws-event): separate AWS event mappers to package
- feat(@lib/create-event-handlers): add abstract factory to create handlers for different aws types
- feat(@services/product): replace @lib/create-gateway-handlers by @lib/create-event-handlers
