### PR TITLE
fix(@lib/create-event-handlers): Correct handling of mutliple events

### DIFF
--- a/lib/aws-events/src/lib/aws-http-response/to-aws-http-error-response.js
+++ b/lib/aws-events/src/lib/aws-http-response/to-aws-http-error-response.js
@@ -3,7 +3,6 @@ import { ErrorTypes } from '@lib/errors';
 import { toAwsHttpResponse } from './to-aws-http-response';
 
 export const toAwsHttpErrorResponse = (error) => {
-  console.debug(error);
   if (isDomain(error))
     return toAwsHttpResponse({
       statusCode: 400,

--- a/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
@@ -33,10 +33,22 @@ export const createEventHandler = ({
       validateAwsEvent(awsEvent);
       const handlerEvent = toHandlerEvent(awsEvent);
       validateHandlerEvent(handlerEvent);
+      console.info(
+        `${name}: try to handle ${awsEventType} type event "${JSON.stringify(
+          handlerEvent,
+        )}"`,
+      );
       const handlerResponse = await handleEvent(handlerEvent);
+      console.info(
+        `${name}: event successfuly handled.\n\tresponse: "${JSON.stringify(
+          handlerResponse,
+        )}"`,
+      );
       validateHandlerResponse(handlerResponse);
       return toSuccessAwsResponse(handlerResponse);
     } catch (error) {
+      console.error(error.message);
+      console.debug(error);
       return toErrorAwsResponse(error);
     }
   };

--- a/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
@@ -2,7 +2,7 @@ import { createValidate } from '@lib/create-validate';
 
 import { createValidateHandlerResponse } from './create-validate-handler-response';
 import { createToHandlerEvent } from './create-to-handler-event';
-import { createHandleResponse } from './create-handle-response';
+import { createHandleEvent } from './create-handle-event';
 
 export const createEventHandler = ({
   name,
@@ -22,14 +22,14 @@ export const createEventHandler = ({
     awsEventType,
     toHandlerEvent: awsEventMappers.event.toHandlerEvent,
   });
-  const handleResponse = createHandleResponse({ type: handlerType, handler });
+  const handleEvent = createHandleEvent({ handlerType, handler });
   const { toSuccessAwsResponse, toErrorAwsResponse } = awsEventMappers.response;
   return async (awsEvent) => {
     try {
       validateAwsEvent(awsEvent);
       const handlerEvent = toHandlerEvent(awsEvent);
       validateHandlerEvent(handlerEvent);
-      const handlerResponse = await handleResponse(handlerEvent);
+      const handlerResponse = await handleEvent(handlerEvent);
       validateHandlerResponse(handlerResponse);
       return toSuccessAwsResponse(handlerResponse);
     } catch (error) {

--- a/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-event-handler.js
@@ -3,6 +3,7 @@ import { createValidate } from '@lib/create-validate';
 import { createValidateHandlerResponse } from './create-validate-handler-response';
 import { createToHandlerEvent } from './create-to-handler-event';
 import { createHandleEvent } from './create-handle-event';
+import { createValidateHandlerEvent } from './create-validate-handler-event';
 
 export const createEventHandler = ({
   name,
@@ -13,7 +14,10 @@ export const createEventHandler = ({
   awsEventMappers,
 }) => {
   const validateAwsEvent = createValidate(awsEventMappers.event.awsEventSchema);
-  const validateHandlerEvent = createValidate(schemas.event);
+  const validateHandlerEvent = createValidateHandlerEvent({
+    handlerType,
+    schema: schemas.event,
+  });
   const validateHandlerResponse = createValidateHandlerResponse({
     name,
     schema: schemas.response,

--- a/lib/create-event-handlers/src/create-event-handler/create-handle-event.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-handle-event.js
@@ -1,8 +1,12 @@
 import { AwsEventHandlerTypes } from '@lib/aws-events';
 
 export const createHandleEvent = ({ handlerType, handler }) => {
-  return (handlerEvent) =>
-    handlerType === AwsEventHandlerTypes.MULTIPLE_EVENTS
-      ? handlerEvent.map(handler)
-      : handler(handlerEvent);
+  return (eventOrEvents) => {
+    if (
+      !Array.isArray(eventOrEvents) ||
+      handlerType === AwsEventHandlerTypes.MULTIPLE_EVENTS
+    )
+      return handler(eventOrEvents);
+    return Promise.all(eventOrEvents.map((event) => handler(event)));
+  };
 };

--- a/lib/create-event-handlers/src/create-event-handler/create-handle-event.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-handle-event.js
@@ -1,8 +1,8 @@
 import { AwsEventHandlerTypes } from '@lib/aws-events';
 
-export const createHandleResponse = ({ type, handler }) => {
+export const createHandleEvent = ({ handlerType, handler }) => {
   return (handlerEvent) =>
-    type === AwsEventHandlerTypes.MULTIPLE_EVENTS
+    handlerType === AwsEventHandlerTypes.MULTIPLE_EVENTS
       ? handlerEvent.map(handler)
       : handler(handlerEvent);
 };

--- a/lib/create-event-handlers/src/create-event-handler/create-handle-event.test.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-handle-event.test.js
@@ -1,0 +1,81 @@
+import { AwsEventHandlerTypes } from '@lib/aws-events';
+
+import { createHandleEvent } from './create-handle-event';
+
+describe('# @lib/createEventHandlers::createHandleEvent', () => {
+  it('should return function', () => {
+    const handleEvent = createHandleEvent({
+      handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+      handler: async () => {},
+    });
+    expect(handleEvent).toStrictEqual(expect.any(Function));
+  });
+
+  describe('## eventHandler', () => {
+    describe('## single event handler', () => {
+      describe('when passed single event', () => {
+        it('should call handler event', async () => {
+          const event = 'event';
+          const handler = jest.fn(async (item) => item);
+          const handleEvents = createHandleEvent({
+            handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+            handler,
+          });
+          const result = await handleEvents(event);
+          expect(result).toStrictEqual(event);
+          expect(handler).toHaveBeenCalledTimes(1);
+          expect(handler).toHaveBeenCalledWith(event);
+        });
+      });
+
+      describe('when passed multiple events', () => {
+        it('should call handler for each event', async () => {
+          const events = ['event1', 'event2', 'event3'];
+          const handler = jest.fn(async (item) => item);
+          const handleEvents = createHandleEvent({
+            handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+            handler,
+          });
+          const result = await handleEvents(events);
+          expect(result).toStrictEqual(events);
+          expect(handler).toHaveBeenCalledTimes(events.length);
+          events.forEach((event, index) => {
+            expect(handler).toHaveBeenNthCalledWith(index + 1, event);
+          });
+        });
+      });
+    });
+
+    describe('## multiple events handler', () => {
+      describe('when passed single event', () => {
+        it('should call handler with event', async () => {
+          const event = 'event1';
+          const handler = jest.fn(async (item) => item);
+          const handleEvents = createHandleEvent({
+            handlerType: AwsEventHandlerTypes.MULTIPLE_EVENTS,
+            handler,
+          });
+          const result = await handleEvents(event);
+          expect(result).toStrictEqual(event);
+          expect(handler).toHaveBeenCalledTimes(1);
+          expect(handler).toHaveBeenCalledWith(event);
+        });
+      });
+
+      describe('when passed multiple events', () => {
+        it('should call handler with array of events', async () => {
+          const events = ['event1', 'event2', 'event3'];
+          const handler = jest.fn(async (item) => item);
+          const handleEvents = createHandleEvent({
+            handlerType: AwsEventHandlerTypes.MULTIPLE_EVENTS,
+            handler,
+          });
+          const result = await handleEvents(events);
+          expect(result).toStrictEqual(events);
+          expect(handler).toHaveBeenCalledTimes(1);
+          expect(handler).toHaveBeenCalledWith(events);
+        });
+      });
+    });
+  });
+});

--- a/lib/create-event-handlers/src/create-event-handler/create-validate-handler-event.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-validate-handler-event.js
@@ -1,0 +1,14 @@
+import { AwsEventHandlerTypes } from '@lib/aws-events';
+import { createValidate } from '@lib/create-validate';
+
+export const createValidateHandlerEvent = ({ handlerType, schema }) => {
+  const validate = createValidate(schema);
+  return (eventOrEvents) => {
+    if (
+      !Array.isArray(eventOrEvents) ||
+      handlerType === AwsEventHandlerTypes.MULTIPLE_EVENTS
+    )
+      return validate(eventOrEvents);
+    return eventOrEvents.map((event) => validate(event));
+  };
+};

--- a/lib/create-event-handlers/src/create-event-handler/create-validate-handler-event.test.js
+++ b/lib/create-event-handlers/src/create-event-handler/create-validate-handler-event.test.js
@@ -1,0 +1,68 @@
+import { AwsEventHandlerTypes } from '@lib/aws-events';
+
+import { createValidateHandlerEvent } from './create-validate-handler-event';
+
+describe('# @lib/createEventHandlers::createValidateHandlerEvent', () => {
+  it('should return function', () => {
+    const schema = {};
+    const handleEvent = createValidateHandlerEvent({
+      handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+      schema,
+    });
+    expect(handleEvent).toStrictEqual(expect.any(Function));
+  });
+
+  describe('## validateHandlerEvent', () => {
+    describe('## single event handler', () => {
+      const schema = { type: 'string' };
+      describe('when passed single event', () => {
+        it('should validate event', async () => {
+          const event = 'event';
+          const validateHandlerEvent = createValidateHandlerEvent({
+            handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+            schema,
+          });
+          expect(() => validateHandlerEvent(event)).not.toThrow();
+        });
+      });
+
+      describe('when passed multiple events', () => {
+        it('should call handler for each event', async () => {
+          const events = ['event1', 'event2', 'event3'];
+          const validateHandlerEvent = createValidateHandlerEvent({
+            handlerType: AwsEventHandlerTypes.SINGLE_EVENT,
+            schema,
+          });
+          expect(() => validateHandlerEvent(events)).not.toThrow();
+        });
+      });
+    });
+
+    describe('## multiple events handler', () => {
+      describe('when passed single event', () => {
+        it('should call handler with event', async () => {
+          const schema = { type: 'string' };
+          const event = 'event1';
+          const validateHandlerEvent = createValidateHandlerEvent({
+            handlerType: AwsEventHandlerTypes.MULTIPLE_EVENTS,
+            schema,
+          });
+          expect(() => validateHandlerEvent(event)).not.toThrow();
+        });
+      });
+
+      describe('when passed multiple events', () => {
+        it('should call handler with array of events', async () => {
+          const schema = { type: 'array', items: { type: 'string' } };
+          const events = ['event1', 'event2', 'event3'];
+          const validateHandlerEvent = createValidateHandlerEvent({
+            handlerType: AwsEventHandlerTypes.MULTIPLE_EVENTS,
+            schema,
+          });
+          const result = await validateHandlerEvent(events);
+          expect(result).toStrictEqual(events);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Incoming AWS event can be an array of events (S3, SQS event can be a batch of events):
- if the handler type is 'single-event', every batch event will be handled separately (provide single event schema with handler) and the result will be an array of results;
- if the handler type is 'multiple-events', the batch will be handled (multiple events schema must be provided with handler) and the handler returns the result of the handling of the events;

- refactor(@lib/create-event-handlers): use "event" instead of "request"
- fix(@lib/create-event-handlers): correct validation and handling of multiple events
- fix(@lib/create-event-handlers): revert logging of handling events
- fix(@lib/aws-events): remove HTTP events logging in the flavor of logging in the handler factory
